### PR TITLE
(fix)FAB & Raised buttons hover and focus colors match material design

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -27,10 +27,10 @@ a.md-button.md-THEME_NAME-theme,
     }
     &:not([disabled]) {
       &:hover {
-        background-color: '{{accent-color}}';
+        background-color: '{{accent-A600}}';
       }
       &.md-focused {
-        background-color: '{{accent-A700}}';
+        background-color: '{{accent-A600}}';
       }
     }
   }
@@ -50,7 +50,7 @@ a.md-button.md-THEME_NAME-theme,
           color: '{{primary-contrast}}';
         }
         &:hover {
-          background-color: '{{primary-color}}';
+          background-color: '{{primary-600}}';
         }
         &.md-focused {
           background-color: '{{primary-600}}';
@@ -72,10 +72,10 @@ a.md-button.md-THEME_NAME-theme,
         color: '{{accent-contrast}}';
       }
       &:hover {
-        background-color: '{{accent-color}}';
+        background-color: '{{accent-A600}}';
       }
       &.md-focused {
-        background-color: '{{accent-A700}}';
+        background-color: '{{accent-A600}}';
       }
     }
   }
@@ -108,10 +108,10 @@ a.md-button.md-THEME_NAME-theme,
           color: '{{warn-contrast}}';
         }
         &:hover {
-          background-color: '{{warn-color}}';
+          background-color: '{{warn-600}}';
         }
         &.md-focused {
-          background-color: '{{warn-700}}';
+          background-color: '{{warn-600}}';
         }
       }
     }
@@ -133,10 +133,10 @@ a.md-button.md-THEME_NAME-theme,
           color: '{{accent-contrast}}';
         }
         &:hover {
-          background-color: '{{accent-color}}';
+          background-color: '{{accent-600}}';
         }
         &.md-focused {
-          background-color: '{{accent-700}}';
+          background-color: '{{accent-600}}';
         }
       }
     }


### PR DESCRIPTION
According to material
Currently, FAB and Raised buttons don't do anything when hovered.

Accord to material [spec](https://www.google.com/design/spec/components/buttons.html#buttons-flat-raised-buttons) they should have the following values:

Regular : 500
Hover : 600
Focused : 600
Pressed : 700

I used a ![colorpicker](http://html-color-codes.info/colors-from-image/) to confirm hover and focused are indeed the same color on this [image](https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0Bx4BSt6jniD7UTh2dExpSlRVWVU/components_buttons_main16.png)
